### PR TITLE
Update proptype for textStyle

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ ViewMoreText.propTypes = {
   afterCollapse: PropTypes.func,
   afterExpand: PropTypes.func,
   numberOfLines: PropTypes.number.isRequired,
-  textStyle: PropTypes.object,
+  textStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
   renderTimeout: PropTypes.number,
 };
 


### PR DESCRIPTION
Styles can be an array of style objects or object. Array gives an effect similar to css.

Previously, this value was set to Text.propTypes.style which would allow arrays to be passed without warning in <1.4.0. After upgrading package, I now this see this warning as I am passing [defaultStyle, themeStyle] as a prop to this component.

<img width="368" alt="screen shot 2018-01-05 at 11 18 24 am" src="https://user-images.githubusercontent.com/3968741/34624496-5ea078ac-f20a-11e7-8f5e-6ddaf23823c1.png">

This will remove this warning.