### PR TITLE
allow support for onTextLayout

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ npm install --save react-native-view-more-text
 - **afterCollapse**(func): Callback after collapsing
 - **afterExpand**(func): Callback after expanding
 
+- **onTextLayout**(func): onTextLayout function is passed to `Text` inside `ViewMoreText`
+(Refer to this [PR#56](https://github.com/nlt2390/react-native-view-more-text/pull/56))
 - **textStyle**([object, array]): Styles is passed to `Text` inside `ViewMoreText`
 (Refer to this [PR#8](https://github.com/nlt2390/react-native-view-more-text/pull/8))
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,8 +7,9 @@ declare module 'react-native-view-more-text' {
     numberOfLines: number;
     renderViewMore?: (handlePress: () => void) => JSX.Element;
     renderViewLess?: (handlePress: () => void) => JSX.Element;
-    afterCollapse?: () => void
-    afterExpand?: () => void
+    afterCollapse?: () => void;
+    afterExpand?: () => void;
+    onTextLayout?: () => void;
     textStyle?: StyleProp<TextStyle>;
   }
   

--- a/index.js
+++ b/index.js
@@ -130,6 +130,7 @@ class ViewMoreText extends React.Component {
         <View onLayout={this.onLayoutTrimmedText}>
           <Text
             style={this.props.textStyle}
+            onTextLayout={this.props.onTextLayout}
             numberOfLines={this.state.numberOfLines}
           >
             {this.props.children}
@@ -144,6 +145,7 @@ class ViewMoreText extends React.Component {
 }
 
 ViewMoreText.propTypes = {
+  onTextLayout: PropTypes.func,
   renderViewMore: PropTypes.func,
   renderViewLess: PropTypes.func,
   afterCollapse: PropTypes.func,


### PR DESCRIPTION
Currently, for my project's needs, I require the use of onTextLayout, and handling it through the child text element doesn't work. Tested these changes and everything works perfectly.